### PR TITLE
Move executables to cmd/<program>/main.go.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-cluster-up
-machine-up
+cmd/machine-up/machine-up
+cmd/cluster-up/cluster-up

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM scratch
 
 MAINTAINER Guilherme Santos <guilherme.santos@neoway.com.br>
 
-ADD ./machine-up /opt/cloud-machine/bin/
-ADD ./cluster-up /opt/cloud-machine/bin/
+ADD ./cmd/machine-up/machine-up /opt/cloud-machine/bin/
+ADD ./cmd/cluster-up/cluster-up /opt/cloud-machine/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,27 @@
-version ?= latest
+version ?= 1.0
 WORKDIR="github.com/NeowayLabs/cloud-machine"
 IMAGENAME=neowaylabs/cloud-machine
 IMAGE=$(IMAGENAME):$(version)
 
 all: machine-up cluster-up
-	@echo "Create: machine-up & cluster-up"
+	@echo "Created: machine-up & cluster-up"
 
 goget:
 	go get -d -v ./...
 
-machine-up: goget
-	go build -v machine-up.go auth.go
+machine-up:
+	cd cmd/machine-up && make build
 
-cluster-up: goget
-	go build -v cluster-up.go auth.go
+cluster-up:
+	cd cmd/cluster-up && make build
 
-install: deploy
+build: machine-up cluster-up
+
+static:
+	cd cmd/machine-up && make static
+	cd cmd/cluster-up && make static
+	ldd cmd/machine-up/machine-up | grep "not a dynamic executable"
+	ldd cmd/cluster-up/cluster-up | grep "not a dynamic executable"
 
 publish: image
 	docker push $(IMAGE)
@@ -23,15 +29,11 @@ publish: image
 image: build
 	docker build -t $(IMAGE) .
 
-build: build-env
-	docker run --rm -v `pwd`:/go/src/$(WORKDIR) --privileged -i -t $(IMAGENAME) bash hack/make.sh
+build-static: build-env
+	docker run --rm -v `pwd`:/go/src/$(WORKDIR) --privileged -i -t $(IMAGENAME) make static
 
 build-env:
 	docker build -t $(IMAGENAME) -f ./hack/Dockerfile .
 
-check: build
-	docker run --rm -v `pwd`:/go/src/$(WORKDIR) --privileged -i -t $(IMAGENAME) bash hack/check.sh
-
-shell: build
+shell: build-env
 	docker run --rm -v `pwd`:/go/src/$(WORKDIR) --privileged -i -t $(IMAGENAME) bash
-

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ WORKDIR="github.com/NeowayLabs/cloud-machine"
 IMAGENAME=neowaylabs/cloud-machine
 IMAGE=$(IMAGENAME):$(version)
 
-all: machine-up cluster-up
+all: goget machine-up cluster-up
 	@echo "Created: machine-up & cluster-up"
 
 goget:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version ?= 1.0
+version ?= latest
 WORKDIR="github.com/NeowayLabs/cloud-machine"
 IMAGENAME=neowaylabs/cloud-machine
 IMAGE=$(IMAGENAME):$(version)

--- a/README.md
+++ b/README.md
@@ -3,40 +3,68 @@
 # Cloud Machine
 
 This is a Go Project that should be used to create a cloud environment. The app
-will create volumes and instance through AWS, although in the next future it'll
-be possible use other backends like Microsoft Azure, Google Cloud Platform, etc.
+create volumes, ec2 instances, security groups, etc, on AWS.
 
-## How compile?
+## Using docker version
 
-The easier way to compile this project is getting
-[Docker](http://docs.docker.com/linux/step_one/) in your **Linux distribuition**.
+The easiest way to use `cloud-machine` is using [Docker](http://docs.docker.com/linux/step_one/) and the
+available
+[cloud-machine image](https://hub.docker.com/r/neowaylabs/cloud-machine/)
+issuing the following commands:
 
-#### Docker at Linux
-
-If you already have Docker installed in your Linux, you can simply type:
-```make```. Two files will be created in root directory of project:
-```machine-up``` and ```cluster-up```
-
-#### Other way
-
-If you have a Docker in other platforms (like MacOS X) you only can use it if
-you execute all commands inside of docker container, because the executables
-was compiled using Ubuntu. If execute all commands inside a Docker container is
-not a problem to you go ahead, otherwise you should install Go to compile them.
-
-To compile the project in your own platfomr, first you need
-[Go](http://golang.org), to install [click here](https://golang.org/doc/install).
-After that, you need to execute following commands, pay attention that we have
-two entry points (```machine-up.go``` and ```cluster-up.go```), because that
-we need to pass ```-d``` to ```go get```
-
+```sh
+$ docker pull neowaylabs/cloud-machine:latest
+$ docker run --rm -it -v <local-config-dir>:/data neowaylabs/cloud-machine:latest /machine-up -h
 ```
-export GOPATH=~/go # change to your go workspace
-go get -d github.com/NeowayLabs/cloud-machine
-cd $GOPATH/src/github.com/NeowayLabs/cloud-machine
-go build machine-up.go auth.go
-go build cluster-up.go auth.go
+
+The `<local-config-dir>` is some directory containing your
+infrastructure configurations (see section [How use?]). This place
+will be mapped to directory `/data` inside container.
+
+Then, a simple usage could be:
+
+```sh
+$ docker run --rm -it -v <local-config-dir>:/data \
+    neowaylabs/cloud-machine:latest \
+    /machine-up /data/mongo-node.yml
 ```
+
+## Compiling the sources
+
+To build `cloud-machine` you'll need [Go >= 1.4](https://golang.org/dl/) or
+use a docker image with Go installed. You can choose one of the
+following commands to build:
+
+```sh
+make build        # build using installed Go
+make build-docker # build using docker
+```
+
+After that, two binaries will be created:
+
+```sh
+$ ./cmd/machine-up/machine-up --help
+Usage of ./cmd/machine-up/machine-up:
+  -access-key string
+    	AWS Access Key
+  -secret-key string
+    	AWS Secret Key
+
+$ ./cmd/cluster-up/cluster-up --help
+Usage of ./cmd/cluster-up/cluster-up:
+  -access-key string
+    	AWS Access Key
+  -secret-key string
+    	AWS Secret Key
+```
+
+If you have Go installed, `make install` will install the binaries
+inside `$GOPATH/bin`.
+
+On OSX the binaries will not work if built with docker because the
+image they were compiled in is an ubuntu. The recommended way in this
+case are installing Go or issuing the commands directly inside the
+development docker image (`make shell-debug`)
 
 ## How use?
 
@@ -144,7 +172,7 @@ volumes:
 ```
 
 To run you need export AWS_ACCESS_KEY and AWS_SECRET_KEY or type ```aws configure``` and pass machine-config
-file 
+file
 
 ```
 export AWS_ACCESS_KEY=<your access key>
@@ -198,7 +226,7 @@ clusters:
 ```
 
 To run you need export AWS_ACCESS_KEY and AWS_SECRET_KEY or type ```aws configure``` and pass cluster-config
-file 
+file
 
 ```
 export AWS_ACCESS_KEY=<your access key>
@@ -208,7 +236,7 @@ export AWS_SECRET_KEY=<your secret key>
 
 aws configure
 
-./cluster-up ./cloud-machine/app-cluster.yml
+cluster-up ./cloud-machine/app-cluster.yml
 ```
 
 ## Publishing the image

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"errors"
@@ -16,7 +16,7 @@ var (
 )
 
 // AwsAuth ...
-func AwsAuth() (auth aws.Auth, err error) {
+func Aws() (auth aws.Auth, err error) {
 	auth.AccessKey = *accessKey
 	auth.SecretKey = *secretKey
 

--- a/cmd/cluster-up/Makefile
+++ b/cmd/cluster-up/Makefile
@@ -1,0 +1,10 @@
+all: build install
+
+build:
+	go build
+
+static:
+	CGO_ENABLED=0 go build -v -a -installsuffix cgo
+
+install:
+	go install

--- a/cmd/cluster-up/Makefile
+++ b/cmd/cluster-up/Makefile
@@ -3,7 +3,7 @@ all: build install
 build:
 	go build
 
-static:
+build-static:
 	CGO_ENABLED=0 go build -v -a -installsuffix cgo
 
 install:

--- a/cmd/cluster-up/main.go
+++ b/cmd/cluster-up/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/NeowayLabs/cloud-machine/auth"
 	"github.com/NeowayLabs/cloud-machine/machine"
 	"github.com/NeowayLabs/cloud-machine/volume"
 	"github.com/NeowayLabs/logger"
@@ -147,7 +148,7 @@ func main() {
 		machines[key] = Cluster{Machine: machineConfig, Nodes: clusterConfig.Nodes}
 	}
 
-	auth, err := AwsAuth()
+	auth, err := auth.Aws()
 	if err != nil {
 		logger.Fatal("Error reading aws credentials: %s", err.Error())
 	}

--- a/cmd/machine-up/Makefile
+++ b/cmd/machine-up/Makefile
@@ -1,0 +1,10 @@
+all: build install
+
+build:
+	go build
+
+static:
+	CGO_ENABLED=0 go build -v -a -installsuffix cgo
+
+install:
+	go install

--- a/cmd/machine-up/Makefile
+++ b/cmd/machine-up/Makefile
@@ -3,7 +3,7 @@ all: build install
 build:
 	go build
 
-static:
+build-static:
 	CGO_ENABLED=0 go build -v -a -installsuffix cgo
 
 install:

--- a/cmd/machine-up/main.go
+++ b/cmd/machine-up/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/NeowayLabs/cloud-machine/auth"
 	"github.com/NeowayLabs/cloud-machine/machine"
 	"github.com/NeowayLabs/logger"
 	"gopkg.in/yaml.v2"
@@ -29,7 +30,7 @@ func main() {
 		logger.Fatal("Error reading machine file: %s", err.Error())
 	}
 
-	auth, err := AwsAuth()
+	auth, err := auth.Aws()
 	if err != nil {
 		logger.Fatal("Error reading aws credentials: %s", err.Error())
 	}

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -25,5 +25,4 @@ ENV CGO_ENABLED 0
 # Upload docker source
 COPY . /go/src/github.com/NeowayLabs/cloud-machine
 
-# Grab Go's cover tool for dead-simple code coverage testing
 RUN go get -d

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -1,2 +1,0 @@
-CGO_ENABLED=0 go build -v -a -installsuffix cgo machine-up.go
-CGO_ENABLED=0 go build -v -a -installsuffix cgo cluster-up.go


### PR DESCRIPTION
- Adjust scripts to work properly;
- Remove unused scripts;

Closes #10
